### PR TITLE
Modifies BaseTransferService to have OAuth2 session as an attribute rather than extending it

### DIFF
--- a/tests/test_transfer_services/test_base.py
+++ b/tests/test_transfer_services/test_base.py
@@ -74,14 +74,14 @@ def test_add_unsupported_vertical_new_scope_required(
             return {'new_scope'}
         return sample_scope
 
-    transfer_service.access_token = 'access_token'
+    transfer_service._oAuth2Session.access_token = 'access_token'
     monkeypatch.setattr(
         transfer_service, 'scope_for_verticals', _mock_scope_for_verticals
     )
     assert not transfer_service.add_verticals(
         [Vertical.NEW_VERTICAL_EXTRA_SCOPE], should_reauth=True
     )
-    assert not transfer_service.access_token
+    assert not transfer_service._oAuth2Session.access_token
     assert transfer_service.scope == {'fake', 'scope', 'new_scope'}
     assert transfer_service.verticals == {
         Vertical.FAKE_VERTICAL,


### PR DESCRIPTION
While working on #5 , I realized that extending [`OAuth2Session`](https://github.com/requests/requests-oauthlib/blob/master/requests_oauthlib/oauth2_session.py) was a bit overkill since we don't need the level of configurability it provides (e.g., [`fetch_token`](https://github.com/requests/requests-oauthlib/blob/master/requests_oauthlib/oauth2_session.py#L202)'s 16 arguments, of which we'll only ever use two).

IIRC, it's usually better not to use inheritance in cases like these anyway (composition over inheritance?).