### PR TITLE
Fixes Github workflow test script

### DIFF
--- a/.github/workflows/python-checks.yml
+++ b/.github/workflows/python-checks.yml
@@ -25,7 +25,7 @@ jobs:
           python-version-file: "pyproject.toml"
 
       - name: Run tests
-        run: uv run pytest tests --cov-fail-under=90
+        run: uv run pytest --cov=src --cov-fail-under=90
 
       - name: Run mypy type check
         run: uv run mypy . --config-file=pyproject.toml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,3 +41,6 @@ line-length = 88
 skip-magic-trailing-comma = true
 quote-style = "single"
 docstring-code-format = true
+
+[tool.coverage.report]
+exclude_also = ['@(abc\.)?abstractmethod']


### PR DESCRIPTION
Closes #29 

`--cov` is what actually invokes the coverage check and we don't need to include abstract methods as testable codepaths.