### PR TITLE
Implements Strava method for fetching activities and adds corresponding vertical

### DIFF
--- a/src/pardner/services/base.py
+++ b/src/pardner/services/base.py
@@ -1,6 +1,7 @@
 from abc import ABC, abstractmethod
 from typing import Any, Iterable, Optional
 
+from requests import Response
 from requests_oauthlib import OAuth2Session
 
 from pardner.services.utils import scope_as_set, scope_as_string
@@ -121,6 +122,20 @@ class BaseTransferService(ABC):
         if len(unsupported_verticals) > 0:
             raise UnsupportedVerticalException(unsupported_verticals, self.name)
         self._verticals = set(verticals)
+
+    def _get_resource(self, uri: str, params: dict[str, Any] = {}) -> Response:
+        """
+        Sends a GET request to `uri` using `OAuth2Session`.
+
+        :param uri: the destination of the request (a URI).
+        :param params: the extra parameters to be send with the request, optionally.
+
+        :returns: The `requests.Response` object obtained from making the request.
+        """
+        dashboard_response = self._oAuth2Session.get(uri, params=params)
+        if not dashboard_response.ok:
+            dashboard_response.raise_for_status()
+        return dashboard_response
 
     def add_verticals(
         self, verticals: Iterable[Vertical], should_reauth: bool = False

--- a/src/pardner/services/base.py
+++ b/src/pardner/services/base.py
@@ -125,17 +125,17 @@ class BaseTransferService(ABC):
 
     def _get_resource(self, uri: str, params: dict[str, Any] = {}) -> Response:
         """
-        Sends a GET request to `uri` using `OAuth2Session`.
+        Sends a GET request to ``uri`` using :class:`OAuth2Session`.
 
         :param uri: the destination of the request (a URI).
         :param params: the extra parameters to be send with the request, optionally.
 
-        :returns: The `requests.Response` object obtained from making the request.
+        :returns: The :class:`requests.Response` object obtained from making the request.
         """
-        dashboard_response = self._oAuth2Session.get(uri, params=params)
-        if not dashboard_response.ok:
-            dashboard_response.raise_for_status()
-        return dashboard_response
+        response = self._oAuth2Session.get(uri, params=params)
+        if not response.ok:
+            response.raise_for_status()
+        return response
 
     def add_verticals(
         self, verticals: Iterable[Vertical], should_reauth: bool = False

--- a/src/pardner/services/tumblr.py
+++ b/src/pardner/services/tumblr.py
@@ -73,17 +73,15 @@ class TumblrTransferService(BaseTransferService):
         """
         dashboard_uri = urljoin(self._base_url, '/v2/user/dashboard')
         if count <= 20:
-            dashboard_response = self._oAuth2Session.get(
+            dashboard_response = self._get_resource(
                 dashboard_uri,
-                params={
+                {
                     'limit': count,
                     'npf': True,
                     'type': 'text' if text_only else '',
                     **request_params,
                 },
             )
-            if not dashboard_response.ok:
-                dashboard_response.raise_for_status()
             return list(dashboard_response.json().get('response').get('posts'))
         raise UnsupportedRequestException(
             self._service_name,

--- a/src/pardner/verticals/base.py
+++ b/src/pardner/verticals/base.py
@@ -8,3 +8,4 @@ class Vertical(StrEnum):
     """
 
     FeedPost = 'feed_post'
+    PhysicalActivity = 'physical_activity'

--- a/tests/test_transfer_services/conftest.py
+++ b/tests/test_transfer_services/conftest.py
@@ -1,9 +1,12 @@
 import pytest
+from requests import Response
 from requests_oauthlib import OAuth2Session
 
 from pardner.services.strava import StravaTransferService
 from pardner.services.tumblr import TumblrTransferService
 from pardner.verticals.base import Vertical
+
+# FIXTURES
 
 
 @pytest.fixture
@@ -32,10 +35,31 @@ def mock_tumblr_transfer_service(verticals=[Vertical.FeedPost]):
 
 
 @pytest.fixture
-def mock_strava_transfer_service(verticals=[Vertical.FeedPost]):
+def mock_strava_transfer_service(verticals=[Vertical.PhysicalActivity]):
     return StravaTransferService(
         'fake_client_id', 'fake_client_secret', 'https://redirect_uri', None, verticals
     )
+
+
+@pytest.fixture
+def mock_oauth2_bad_response(mocker):
+    mock_response = mocker.create_autospec(Response)
+    mock_response.ok = False
+    mock_response.status_code = 400
+    mock_response.reason = 'fake reason'
+    mock_response.url = 'fake url'
+    mock_response.raise_for_status = lambda: Response.raise_for_status(mock_response)
+    return mock_response
+
+
+@pytest.fixture
+def mock_oauth2_session_get_bad_response(mocker, mock_oauth2_bad_response):
+    oauth2_session_get = mocker.patch.object(OAuth2Session, 'get', autospec=True)
+    oauth2_session_get.return_value = mock_oauth2_bad_response
+    return oauth2_session_get
+
+
+# HELPERS
 
 
 def mock_oauth2_session_get(mocker, response_object):

--- a/tests/test_transfer_services/test_strava.py
+++ b/tests/test_transfer_services/test_strava.py
@@ -1,9 +1,12 @@
 import pytest
+from requests import HTTPError
 
-from pardner.services.base import UnsupportedVerticalException
+from pardner.services.base import (
+    UnsupportedRequestException,
+    UnsupportedVerticalException,
+)
 from pardner.verticals import Vertical
-
-sample_scope = {'fake', 'scope'}
+from tests.test_transfer_services.conftest import mock_oauth2_session_get
 
 
 def test_scope(mock_strava_transfer_service):
@@ -12,7 +15,7 @@ def test_scope(mock_strava_transfer_service):
 
 @pytest.mark.parametrize(
     ['verticals', 'expected_scope'],
-    [([], set()), ([Vertical.FeedPost], {'activity:read', 'profile:read_all'})],
+    [([], set()), ([Vertical.PhysicalActivity], {'activity:read', 'profile:read_all'})],
 )
 def test_scope_for_verticals(mock_strava_transfer_service, verticals, expected_scope):
     assert mock_strava_transfer_service.scope_for_verticals(verticals) == expected_scope
@@ -21,3 +24,30 @@ def test_scope_for_verticals(mock_strava_transfer_service, verticals, expected_s
 def test_scope_for_verticals_raises_error(mock_strava_transfer_service, mock_vertical):
     with pytest.raises(UnsupportedVerticalException):
         mock_strava_transfer_service.scope_for_verticals([Vertical.NEW_VERTICAL])
+
+
+def test_fetch_athlete_activities_raises_exception(mock_strava_transfer_service):
+    with pytest.raises(UnsupportedRequestException):
+        mock_strava_transfer_service.fetch_athlete_activities(count=31)
+
+
+def test_fetch_athlete_activities_raises_http_exception(
+    mock_strava_transfer_service, mock_oauth2_session_get_bad_response
+):
+    with pytest.raises(HTTPError):
+        mock_strava_transfer_service.fetch_athlete_activities()
+
+
+def test_fetch_athlete_activities(mocker, mock_strava_transfer_service):
+    sample_response = [{'object': 1}, {'object': 2}]
+
+    response_object = mocker.MagicMock()
+    response_object.json.return_value = sample_response
+
+    oauth2_session_get = mock_oauth2_session_get(mocker, response_object)
+
+    assert mock_strava_transfer_service.fetch_athlete_activities() == sample_response
+    assert (
+        oauth2_session_get.call_args.args[1]
+        == 'https://www.strava.com/api/v3/athlete/activities'
+    )

--- a/tests/test_transfer_services/test_tumblr.py
+++ b/tests/test_transfer_services/test_tumblr.py
@@ -1,11 +1,9 @@
 import pytest
-from requests import HTTPError, Response
+from requests import HTTPError
 
 from pardner.services.base import UnsupportedRequestException
 from pardner.verticals import Vertical
 from tests.test_transfer_services.conftest import mock_oauth2_session_get
-
-sample_scope = {'fake', 'scope'}
 
 
 @pytest.mark.parametrize(
@@ -20,16 +18,9 @@ def test_fetch_feed_posts_raises_exception(mock_tumblr_transfer_service):
         mock_tumblr_transfer_service.fetch_feed_posts(count=21)
 
 
-def test_fetch_feed_posts_raises_http_exception(mocker, mock_tumblr_transfer_service):
-    mock_response = mocker.create_autospec(Response)
-    mock_response.ok = False
-    mock_response.status_code = 400
-    mock_response.reason = 'fake reason'
-    mock_response.url = 'fake url'
-    mock_response.raise_for_status = lambda: Response.raise_for_status(mock_response)
-
-    mock_oauth2_session_get(mocker, mock_response)
-
+def test_fetch_feed_posts_raises_http_exception(
+    mock_tumblr_transfer_service, mock_oauth2_session_get_bad_response
+):
     with pytest.raises(HTTPError):
         mock_tumblr_transfer_service.fetch_feed_posts()
 


### PR DESCRIPTION
Closes #42 

Some constraints with the Strava API:
* When you make the lowest tier Strava application, you're only allowed one authorized user at a time. If you apply for more permissions, you can have additional users.
* The single authorized user for the lowest tier can be anyone, it doesn't have to be the creator of the application.
* The interactions with the API (i.e., the types of requests and responses) are identical for any tier, so what I've written in this PR should work for tiers with more permissions too.

I also extract the OAuth2 Session GET request call into the base class for generalizability.

<details>
<summary>Sample response</summary>
<br />

```json
[
    {
        "resource_state": 2,
        "athlete": {"id": 111, "resource_state": 1},
        "name": "Afternoon Run",
        "distance": 111,
        "moving_time": 111,
        "elapsed_time": 111,
        "total_elevation_gain": 0.0,
        "type": "Run",
        "sport_type": "Run",
        "workout_type": 0,
        "id": 14676384061,
        "start_date": "2025-06-02T20:47:04Z",
        "start_date_local": "2025-06-02T15:47:04Z",
        "timezone": "(GMT-06:00) America/Chicago",
        "utc_offset": -18000.0,
        "location_city": null,
        "location_state": null,
        "location_country": null,
        "achievement_count": 0,
        "kudos_count": 1,
        "comment_count": 0,
        "athlete_count": 1,
        "photo_count": 0,
        "map": {
            "id": "111",
            "summary_polyline": "111111111111",
            "resource_state": 2,
        },
        "trainer": false,
        "commute": false,
        "manual": false,
        "private": false,
        "visibility": "followers_only",
        "flagged": false,
        "gear_id": null,
        "start_latlng": [111.111, -111.111],
        "end_latlng": [111.111, -111.111],
        "average_speed": 111.111,
        "max_speed": 111.111,
        "has_heartrate": false,
        "heartrate_opt_out": false,
        "display_hide_heartrate_option": false,
        "elev_high": 111.111,
        "elev_low": 111.111,
        "upload_id": 111,
        "upload_id_str": "111",
        "external_id": "111-activity.fit",
        "from_accepted_tag": false,
        "pr_count": 0,
        "total_photo_count": 0,
        "has_kudoed": false,
    }
]
```
</details>