### PR TITLE
Adds generic `fetch_vertical` method and re-organizes code structure

### DIFF
--- a/src/pardner/__init__.py
+++ b/src/pardner/__init__.py
@@ -1,2 +1,3 @@
+from pardner import exceptions as exceptions
 from pardner import services as services
 from pardner import verticals as verticals

--- a/src/pardner/exceptions.py
+++ b/src/pardner/exceptions.py
@@ -1,0 +1,24 @@
+from pardner.verticals import Vertical
+
+
+class InsufficientScopeException(Exception):
+    def __init__(self, *unsupported_verticals: Vertical, service_name: str) -> None:
+        combined_verticals = ', '.join(unsupported_verticals)
+        super().__init__(
+            f'Cannot add {combined_verticals} to {service_name} with current scope.'
+        )
+
+
+class UnsupportedVerticalException(Exception):
+    def __init__(self, *unsupported_verticals: Vertical, service_name: str) -> None:
+        combined_verticals = ', '.join(unsupported_verticals)
+        is_more_than_one_vertical = len(unsupported_verticals) > 1
+        super().__init__(
+            f'Cannot fetch {combined_verticals} from {service_name} because '
+            f'{"they are" if is_more_than_one_vertical else "it is"} not supported.'
+        )
+
+
+class UnsupportedRequestException(Exception):
+    def __init__(self, service_name: str, message: str):
+        super().__init__(f'Cannot fetch data from {service_name}: {message}')

--- a/src/pardner/services/strava.py
+++ b/src/pardner/services/strava.py
@@ -1,10 +1,7 @@
 from typing import Any, Iterable, Optional, override
 
-from pardner.services.base import (
-    BaseTransferService,
-    UnsupportedRequestException,
-    UnsupportedVerticalException,
-)
+from pardner.exceptions import UnsupportedRequestException, UnsupportedVerticalException
+from pardner.services import BaseTransferService
 from pardner.services.utils import scope_as_set, scope_as_string
 from pardner.verticals import Vertical
 
@@ -59,14 +56,16 @@ class StravaTransferService(BaseTransferService):
     def scope_for_verticals(self, verticals: Iterable[Vertical]) -> set[str]:
         sub_scopes: set[str] = set()
         for vertical in verticals:
-            if vertical not in self._supported_verticals:
-                raise UnsupportedVerticalException([vertical], self._service_name)
+            if not self.is_vertical_supported(vertical):
+                raise UnsupportedVerticalException(
+                    vertical, service_name=self._service_name
+                )
             if vertical == Vertical.PhysicalActivity:
                 sub_scopes.update(['activity:read', 'profile:read_all'])
         return sub_scopes
 
-    def fetch_athlete_activities(
-        self, count: int = 30, request_params: dict[str, Any] = {}
+    def fetch_physical_activities(
+        self, request_params: dict[str, Any] = {}, count: int = 30
     ) -> list[Any]:
         """
         Fetches and returns activities completed by the authorized user.

--- a/src/pardner/services/tumblr.py
+++ b/src/pardner/services/tumblr.py
@@ -1,7 +1,7 @@
 from typing import Any, Iterable, Optional, override
 
+from pardner.exceptions import UnsupportedRequestException
 from pardner.services import BaseTransferService
-from pardner.services.base import UnsupportedRequestException
 from pardner.verticals import Vertical
 
 
@@ -50,9 +50,9 @@ class TumblrTransferService(BaseTransferService):
 
     def fetch_feed_posts(
         self,
+        request_params: dict[str, Any] = {},
         count: int = 20,
         text_only: bool = True,
-        request_params: dict[str, Any] = {},
     ) -> list[Any]:
         """
         Fetches posts from Tumblr feed for user account whose token was

--- a/src/pardner/verticals/base.py
+++ b/src/pardner/verticals/base.py
@@ -1,16 +1,25 @@
 from enum import StrEnum
+from typing import Optional
 
 
 class Vertical(StrEnum):
     """
-    Represents the verticals, or categories of data, that are supported by `pardner`.
+    Represents the verticals, or categories of data, that are supported by this library.
     Not all verticals are supported by every transfer service.
     """
 
     BlockedUser = 'blocked_user'
     ChatBot = 'chat_bot'
-    ConversationDirect = 'conversation_direct'
-    ConversationGroup = 'conversation_group'
+    ConversationDirect = 'conversation_direct', 'conversations_direct'
+    ConversationGroup = 'conversation_group', 'conversations_group'
     ConversationMessage = 'conversation_message'
     FeedPost = 'feed_post'
-    PhysicalActivity = 'physical_activity'
+    PhysicalActivity = 'physical_activity', 'physical_activities'
+
+    plural: str
+
+    def __new__(cls, singular: str, plural: Optional[str] = None) -> 'Vertical':
+        vertical_obj = str.__new__(cls, singular)
+        vertical_obj._value_ = singular
+        vertical_obj.plural = plural if plural else f'{singular}s'
+        return vertical_obj

--- a/tests/test_transfer_services/test_groupme.py
+++ b/tests/test_transfer_services/test_groupme.py
@@ -1,6 +1,6 @@
 import pytest
 
-from pardner.services.base import UnsupportedRequestException
+from pardner.exceptions import UnsupportedRequestException
 from tests.test_transfer_services.conftest import mock_oauth2_session_get
 
 USER_ID = 'fake_user_id'

--- a/tests/test_transfer_services/test_strava.py
+++ b/tests/test_transfer_services/test_strava.py
@@ -1,10 +1,7 @@
 import pytest
 from requests import HTTPError
 
-from pardner.services.base import (
-    UnsupportedRequestException,
-    UnsupportedVerticalException,
-)
+from pardner.exceptions import UnsupportedRequestException, UnsupportedVerticalException
 from pardner.verticals import Vertical
 from tests.test_transfer_services.conftest import mock_oauth2_session_get
 
@@ -26,19 +23,19 @@ def test_scope_for_verticals_raises_error(mock_strava_transfer_service, mock_ver
         mock_strava_transfer_service.scope_for_verticals([Vertical.NEW_VERTICAL])
 
 
-def test_fetch_athlete_activities_raises_exception(mock_strava_transfer_service):
+def test_fetch_physical_activities_raises_exception(mock_strava_transfer_service):
     with pytest.raises(UnsupportedRequestException):
-        mock_strava_transfer_service.fetch_athlete_activities(count=31)
+        mock_strava_transfer_service.fetch_physical_activities(count=31)
 
 
-def test_fetch_athlete_activities_raises_http_exception(
+def test_fetch_physical_activities_raises_http_exception(
     mock_strava_transfer_service, mock_oauth2_session_get_bad_response
 ):
     with pytest.raises(HTTPError):
-        mock_strava_transfer_service.fetch_athlete_activities()
+        mock_strava_transfer_service.fetch_physical_activities()
 
 
-def test_fetch_athlete_activities(mocker, mock_strava_transfer_service):
+def test_fetch_physical_activities(mocker, mock_strava_transfer_service):
     sample_response = [{'object': 1}, {'object': 2}]
 
     response_object = mocker.MagicMock()
@@ -46,7 +43,7 @@ def test_fetch_athlete_activities(mocker, mock_strava_transfer_service):
 
     oauth2_session_get = mock_oauth2_session_get(mocker, response_object)
 
-    assert mock_strava_transfer_service.fetch_athlete_activities() == sample_response
+    assert mock_strava_transfer_service.fetch_physical_activities() == sample_response
     assert (
         oauth2_session_get.call_args.args[1]
         == 'https://www.strava.com/api/v3/athlete/activities'

--- a/tests/test_transfer_services/test_transfer_services_common.py
+++ b/tests/test_transfer_services/test_transfer_services_common.py
@@ -1,5 +1,8 @@
 import pytest
 
+from pardner.exceptions import UnsupportedVerticalException
+from pardner.verticals import Vertical
+
 
 @pytest.mark.parametrize(
     'mock_transfer_service_name',
@@ -19,3 +22,23 @@ def test_fetch_token(
         mock_oauth2_session_request.call_args.kwargs['data']['client_id']
         == 'fake_client_id'
     )
+
+
+@pytest.mark.parametrize(
+    'mock_transfer_service_name',
+    [
+        'mock_tumblr_transfer_service',
+        'mock_strava_transfer_service',
+        'mock_groupme_transfer_service',
+    ],
+)
+def test_fetch_vertical_generic(
+    request, mock_oauth2_session_get_good_response, mock_transfer_service_name
+):
+    mock_transfer_service = request.getfixturevalue(mock_transfer_service_name)
+    for vertical in Vertical:
+        if not mock_transfer_service.is_vertical_supported(vertical):
+            with pytest.raises(UnsupportedVerticalException):
+                mock_transfer_service.fetch(vertical)
+        else:
+            mock_transfer_service.fetch(vertical)

--- a/tests/test_transfer_services/test_tumblr.py
+++ b/tests/test_transfer_services/test_tumblr.py
@@ -1,7 +1,7 @@
 import pytest
 from requests import HTTPError
 
-from pardner.services.base import UnsupportedRequestException
+from pardner.exceptions import UnsupportedRequestException
 from pardner.verticals import Vertical
 from tests.test_transfer_services.conftest import mock_oauth2_session_get
 


### PR DESCRIPTION
Closes #48 

## `fetch_vertical`
- Takes in a `vertical`, `request_params` for to be sent in the actual HTTP request, and `params`, which are optional key-word arguments specific to each method.
- Works by using the vertical's plural name to generate the method name and calling that with the latter two arguments described above. May seem a little risky to call a method based on a name, but given that we check if the vertical is supported and generate the method names based on the vertical names, I think it should be okay (and I wrote tests). As always, open to feedback!
- For the sake of consistency, I added a `request_params` argument to every `fetch_` method (which I think is smart anyway since our pardners may want fine-grained configurability and may have familiarity with the APIs).

## Exception reorganization
- Moved all exception definitions from `services/base.py` to `exceptions.py`
- Made the list arguments in the exceptions constructors optionally lists to get around having to generate one element lists to raise the exception.

## Misc
- Made helper method (`is_vertical_supported(...)`) for checking if a vertical is supported using `_supported_verticals` since it's not unexpected that our pardners may want to check before adding a vertical
- Renamed `fetch_athlete_activities(...)` to `fetch_physical_activities(...)` for consistency
- Moved `request_params` to be first argument in all the `fetch_` methods.