### PR TITLE
Sets `_user_id` to be None by default

### DIFF
--- a/src/pardner/services/groupme.py
+++ b/src/pardner/services/groupme.py
@@ -31,7 +31,7 @@ class GroupMeTransferService(BaseTransferService):
     _authorization_url = 'https://oauth.groupme.com/oauth/authorize'
     _base_url = 'https://api.groupme.com/v3/'
     _token_url = 'https://oauth.groupme.com/oauth/authorize'
-    _user_id: str | None
+    _user_id: str | None = None
 
     def __init__(
         self, client_id: str, redirect_uri: str, verticals: set[Vertical] = set()


### PR DESCRIPTION
Closes #59 

Would crash before because it would check if `self._user_id` had been set to something other than `None` before it was every initialized.