### PR TITLE
Removes misleading `mock_` prefix in test variables that were not mocks

### DIFF
--- a/tests/test_transfer_services/conftest.py
+++ b/tests/test_transfer_services/conftest.py
@@ -54,14 +54,14 @@ def mock_oauth2_session_response(mocker):
 
 
 @pytest.fixture
-def mock_tumblr_transfer_service(verticals=[SocialPostingVertical]):
+def tumblr_transfer_service(verticals=[SocialPostingVertical]):
     return TumblrTransferService(
         'fake_client_id', 'fake_client_secret', 'https://redirect_uri', None, verticals
     )
 
 
 @pytest.fixture
-def mock_strava_transfer_service(verticals=[PhysicalActivityVertical]):
+def strava_transfer_service(verticals=[PhysicalActivityVertical]):
     return StravaTransferService(
         'fake_client_id', 'fake_client_secret', 'https://redirect_uri', None, verticals
     )

--- a/tests/test_transfer_services/test_base.py
+++ b/tests/test_transfer_services/test_base.py
@@ -113,16 +113,6 @@ def test_fetch_token_raises_error(mock_transfer_service):
         mock_transfer_service.fetch_token()
 
 
-def test_fetch_token(
-    mock_oauth2_session_request,
-    mock_oauth2_session_response,
-    mock_strava_transfer_service,
-):
-    mock_strava_transfer_service.fetch_token(code='123code123')
-    mock_oauth2_session_request.assert_called_once()
-    mock_oauth2_session_response.assert_called_once()
-
-
 @pytest.mark.parametrize(
     ['path', 'base'],
     [

--- a/tests/test_transfer_services/test_strava.py
+++ b/tests/test_transfer_services/test_strava.py
@@ -13,36 +13,36 @@ from tests.test_transfer_services.conftest import (
 )
 
 
-def test_scope(mock_strava_transfer_service):
-    mock_strava_transfer_service.scope == 'activity:read,profile:read_all'
+def test_scope(strava_transfer_service):
+    strava_transfer_service.scope == 'activity:read,profile:read_all'
 
 
 @pytest.mark.parametrize(
     ['verticals', 'expected_scope'],
     [([], set()), ([PhysicalActivityVertical], {'activity:read', 'profile:read_all'})],
 )
-def test_scope_for_verticals(mock_strava_transfer_service, verticals, expected_scope):
-    assert mock_strava_transfer_service.scope_for_verticals(verticals) == expected_scope
+def test_scope_for_verticals(strava_transfer_service, verticals, expected_scope):
+    assert strava_transfer_service.scope_for_verticals(verticals) == expected_scope
 
 
-def test_scope_for_verticals_raises_error(mock_strava_transfer_service):
+def test_scope_for_verticals_raises_error(strava_transfer_service):
     with pytest.raises(UnsupportedVerticalException):
-        mock_strava_transfer_service.scope_for_verticals([NewVertical])
+        strava_transfer_service.scope_for_verticals([NewVertical])
 
 
-def test_fetch_physical_activity_raises_exception(mock_strava_transfer_service):
+def test_fetch_physical_activity_raises_exception(strava_transfer_service):
     with pytest.raises(UnsupportedRequestException):
-        mock_strava_transfer_service.fetch_physical_activity_vertical(count=31)
+        strava_transfer_service.fetch_physical_activity_vertical(count=31)
 
 
 def test_fetch_physical_activity_vertical_raises_http_exception(
-    mock_strava_transfer_service, mock_oauth2_session_get_bad_response
+    strava_transfer_service, mock_oauth2_session_get_bad_response
 ):
     with pytest.raises(HTTPError):
-        mock_strava_transfer_service.fetch_physical_activity_vertical()
+        strava_transfer_service.fetch_physical_activity_vertical()
 
 
-def test_fetch_physical_activity_vertical(mocker, mock_strava_transfer_service):
+def test_fetch_physical_activity_vertical(mocker, strava_transfer_service):
     # Adapted from
     # https://developers.strava.com/docs/reference/#api-Activities-getLoggedInAthleteActivities
     sample_response = [
@@ -169,7 +169,7 @@ def test_fetch_physical_activity_vertical(mocker, mock_strava_transfer_service):
 
     oauth2_session_get = mock_oauth2_session_get(mocker, response_object)
 
-    model_objs, _ = mock_strava_transfer_service.fetch_physical_activity_vertical()
+    model_objs, _ = strava_transfer_service.fetch_physical_activity_vertical()
     model_obj_dumps = dump_and_filter_model_objs(model_objs)
 
     assert (

--- a/tests/test_transfer_services/test_transfer_services_common.py
+++ b/tests/test_transfer_services/test_transfer_services_common.py
@@ -5,16 +5,16 @@ from pardner.verticals import Vertical
 
 
 @pytest.mark.parametrize(
-    'mock_transfer_service_name',
-    ['mock_tumblr_transfer_service', 'mock_strava_transfer_service'],
+    'transfer_service_fixture_name',
+    ['tumblr_transfer_service', 'strava_transfer_service'],
 )
 def test_fetch_token(
     mock_oauth2_session_request,
     mock_oauth2_session_response,
     request,
-    mock_transfer_service_name,
+    transfer_service_fixture_name,
 ):
-    mock_transfer_service = request.getfixturevalue(mock_transfer_service_name)
+    mock_transfer_service = request.getfixturevalue(transfer_service_fixture_name)
     mock_transfer_service.fetch_token(code='123code123')
     mock_oauth2_session_request.assert_called_once()
     assert 'client_id' in mock_oauth2_session_request.call_args.kwargs['data']
@@ -25,17 +25,13 @@ def test_fetch_token(
 
 
 @pytest.mark.parametrize(
-    'mock_transfer_service_name',
-    [
-        'mock_tumblr_transfer_service',
-        'mock_strava_transfer_service',
-        'groupme_transfer_service',
-    ],
+    'transfer_service_fixture_name',
+    ['tumblr_transfer_service', 'strava_transfer_service', 'groupme_transfer_service'],
 )
 def test_fetch_vertical_generic(
-    request, mock_oauth2_session_get_good_response, mock_transfer_service_name
+    request, mock_oauth2_session_get_good_response, transfer_service_fixture_name
 ):
-    mock_transfer_service = request.getfixturevalue(mock_transfer_service_name)
+    mock_transfer_service = request.getfixturevalue(transfer_service_fixture_name)
     for vertical in Vertical:
         if not mock_transfer_service.is_vertical_supported(vertical):
             with pytest.raises(UnsupportedVerticalException):

--- a/tests/test_transfer_services/test_tumblr.py
+++ b/tests/test_transfer_services/test_tumblr.py
@@ -10,29 +10,29 @@ from tests.test_transfer_services.conftest import mock_oauth2_session_get
     ['verticals', 'expected_scope'],
     [([], {'basic'}), ([SocialPostingVertical, {'basic'}])],
 )
-def test_scope_for_vertical(mock_tumblr_transfer_service, verticals, expected_scope):
-    assert mock_tumblr_transfer_service.scope_for_verticals(verticals) == expected_scope
+def test_scope_for_vertical(tumblr_transfer_service, verticals, expected_scope):
+    assert tumblr_transfer_service.scope_for_verticals(verticals) == expected_scope
 
 
-def test_fetch_social_posting_vertical_raises_exception(mock_tumblr_transfer_service):
+def test_fetch_social_posting_vertical_raises_exception(tumblr_transfer_service):
     with pytest.raises(UnsupportedRequestException):
-        mock_tumblr_transfer_service.fetch_social_posting_vertical(count=21)
+        tumblr_transfer_service.fetch_social_posting_vertical(count=21)
 
 
 def test_fetch_social_posting_vertical_raises_http_exception(
-    mock_tumblr_transfer_service, mock_oauth2_session_get_bad_response
+    tumblr_transfer_service, mock_oauth2_session_get_bad_response
 ):
     with pytest.raises(HTTPError):
-        mock_tumblr_transfer_service.fetch_social_posting_vertical()
+        tumblr_transfer_service.fetch_social_posting_vertical()
 
 
-def test_fetch_social_posting_vertical(mocker, mock_tumblr_transfer_service):
+def test_fetch_social_posting_vertical(mocker, tumblr_transfer_service):
     response_object = mocker.MagicMock()
     response_object.json.return_value = {'response': {'posts': ['sample', 'posts']}}
 
     oauth2_session_get = mock_oauth2_session_get(mocker, response_object)
 
-    assert mock_tumblr_transfer_service.fetch_social_posting_vertical() == [
+    assert tumblr_transfer_service.fetch_social_posting_vertical() == [
         'sample',
         'posts',
     ]


### PR DESCRIPTION
Closes #74 

Noop PR