### PR TITLE
Fix Tumblr fetch when text_only=False

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "pardner"
 version = "0.0.1"
 description = "Python library for authorizing access and fetching personal data from portability APIs and services"
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.11,<3.14"
 classifiers = [
     "Programming Language :: Python :: 3",
     "Operating System :: OS Independent",

--- a/src/pardner/services/tumblr.py
+++ b/src/pardner/services/tumblr.py
@@ -71,14 +71,12 @@ class TumblrTransferService(BaseTransferService):
         made.
         """
         if count <= 20:
+            params: dict[str, Any] = {'limit': count, 'npf': True, **request_params}
+            if text_only:
+                params['type'] = 'text'
             dashboard_response = self._get_resource_from_path(
                 'user/dashboard',
-                {
-                    'limit': count,
-                    'npf': True,
-                    'type': 'text' if text_only else '',
-                    **request_params,
-                },
+                params,
             )
             return list(dashboard_response.json().get('response').get('posts'))
         raise UnsupportedRequestException(


### PR DESCRIPTION
Calling `fetch_social_posting_vertical(text_only=False)` returns a 404 from Tumblr's API because the code was sending `type=` (empty string) as a query parameter.

When `text_only=False`, omit the `type` parameter entirely. Tumblr accepts no `type` to mean "all types" but rejects `type=`.

Closes #81 

Update: This PR also closes #82 